### PR TITLE
bug fixed: startActivityForResult() in KKFragment doesn't work properly

### DIFF
--- a/src/com/kkbox/toolkit/app/KKFragmentActivity.java
+++ b/src/com/kkbox/toolkit/app/KKFragmentActivity.java
@@ -90,4 +90,10 @@ public class KKFragmentActivity extends FragmentActivity implements KKServiceAct
 		super.onDestroy();
 		delegate.onDestroy();
 	}
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        delegate.onActivityResult(requestCode, resultCode, data);
+    }
 }


### PR DESCRIPTION
can't receive onActivityResult() in KKFragment, cause KKFragment override the startActivityForResult() but no one handle it!!